### PR TITLE
feat: add page for game start (28-25)

### DIFF
--- a/packages/client/src/components/ui/loader-spinner/loading-spinner.pcss
+++ b/packages/client/src/components/ui/loader-spinner/loading-spinner.pcss
@@ -1,0 +1,18 @@
+@keyframes spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-spinner {
+  width: 100px;
+  height: 100px;
+  border: 10px solid var(--gray-900);
+  border-top: 10px solid var(--white);
+  border-radius: 50%;
+  animation: spinner 1s linear infinite;
+}

--- a/packages/client/src/components/ui/loader-spinner/loading-spinner.tsx
+++ b/packages/client/src/components/ui/loader-spinner/loading-spinner.tsx
@@ -1,0 +1,5 @@
+import './loading-spinner.pcss'
+
+export default function LoadingSpinner() {
+  return <div className="loading-spinner"></div>
+}

--- a/packages/client/src/pages/game/game-page.pcss
+++ b/packages/client/src/pages/game/game-page.pcss
@@ -31,6 +31,7 @@
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
   }

--- a/packages/client/src/pages/game/game-page.pcss
+++ b/packages/client/src/pages/game/game-page.pcss
@@ -1,8 +1,37 @@
 .game-page {
   width: 100%;
   padding-top: 96px;
+  flex-grow: 1;
 
-  .wrapper {
-    margin: 0 auto;
+  &__container {
+    width: fit-content;
+    height: fit-content;
+    position: relative;
+  }
+
+  &__overlay {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: var(--gray-900);
+    border-radius: 16px;
+  }
+
+  &__loading-spinner {
+    width: 100px;
+    height: 100px;
+    border: 10px solid var(--gray-900);
+    border-top: 10px solid var(--white);
+    border-radius: 50%;
+    animation: spinner 1s linear infinite;
+  }
+}
+
+@keyframes spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
   }
 }

--- a/packages/client/src/pages/game/game-page.pcss
+++ b/packages/client/src/pages/game/game-page.pcss
@@ -16,23 +16,4 @@
     background-color: var(--gray-900);
     border-radius: 16px;
   }
-
-  &__loading-spinner {
-    width: 100px;
-    height: 100px;
-    border: 10px solid var(--gray-900);
-    border-top: 10px solid var(--white);
-    border-radius: 50%;
-    animation: spinner 1s linear infinite;
-  }
-}
-
-@keyframes spinner {
-  0% {
-    transform: rotate(0deg);
-  }
-
-  100% {
-    transform: rotate(360deg);
-  }
 }

--- a/packages/client/src/pages/game/game-page.tsx
+++ b/packages/client/src/pages/game/game-page.tsx
@@ -1,11 +1,36 @@
-import GameCanvas from '../../components/game/gameState/gameState'
+import { useState } from 'react'
+import Button from '../../components/ui/button/button'
 import './game-page.pcss'
+import GameCanvas from '../../components/game/gameState/gameState'
+
+const GAME_LOADING_TIMER = 3000
 
 function GamePage() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [isPlaying, setIsPlaying] = useState(false)
+
+  const onClick = () => {
+    setIsLoading(true)
+    setTimeout(() => {
+      setIsLoading(false)
+      setIsPlaying(true)
+    }, GAME_LOADING_TIMER)
+  }
+
   return (
-    <div className="game-page">
-      <GameCanvas />
-    </div>
+    <main className="game-page flex flex-jc-center">
+      <div className="game-page__container">
+        {!isPlaying && (
+          <div className="game-page__overlay flex flex-jc-center flex-ai-center">
+            {isLoading && <div className="game-page__loading-spinner"></div>}
+            {!isLoading && (
+              <Button name="play" children="Играть" onClick={onClick} />
+            )}
+          </div>
+        )}
+        <GameCanvas />
+      </div>
+    </main>
   )
 }
 

--- a/packages/client/src/pages/game/game-page.tsx
+++ b/packages/client/src/pages/game/game-page.tsx
@@ -22,8 +22,9 @@ function GamePage() {
       <div className="game-page__container">
         {!isPlaying && (
           <div className="game-page__overlay flex flex-jc-center flex-ai-center">
-            {isLoading && <div className="game-page__loading-spinner"></div>}
-            {!isLoading && (
+            {isLoading ? (
+              <div className="game-page__loading-spinner"></div>
+            ) : (
               <Button name="play" children="Играть" onClick={onClick} />
             )}
           </div>

--- a/packages/client/src/pages/game/game-page.tsx
+++ b/packages/client/src/pages/game/game-page.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import Button from '../../components/ui/button/button'
 import './game-page.pcss'
 import GameCanvas from '../../components/game/gameState/gameState'
+import LoadingSpinner from '../../components/ui/loader-spinner/loading-spinner'
 
 const GAME_LOADING_TIMER = 3000
 
@@ -23,7 +24,7 @@ function GamePage() {
         {!isPlaying && (
           <div className="game-page__overlay flex flex-jc-center flex-ai-center">
             {isLoading ? (
-              <div className="game-page__loading-spinner"></div>
+              <LoadingSpinner />
             ) : (
               <Button name="play" children="Играть" onClick={onClick} />
             )}


### PR DESCRIPTION
### Сверстать экран с началом игры — например, обратный отсчёт, лоадер, экран с подсказками о том, как играть, или просто кнопка «Старт»
Игра подгружается сразу. Поверх overlay. При нажатии на кнопку старт запускается таймаут на 3 сек, после чего отображается игра. Потом, при желании, можно подгружать игру в lazy формате на фоне


### Скриншоты/видяшка (если есть)

### TBD (если есть)